### PR TITLE
Add basic scaffolding for distributing the package

### DIFF
--- a/numpy/__init__.pyi
+++ b/numpy/__init__.pyi
@@ -1,0 +1,12 @@
+# very simple, just enough to start running tests
+
+class ndarray: pass
+
+class dtype: pass
+
+def array(
+    object: object,
+    dtype: dtype = ...,
+    copy: bool = ...,
+    subok: bool = ...,
+    ndmin: int = ...) -> ndarray: ...

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='numpy_stubs',
+    maintainer="NumPy Developers",
+    maintainer_email="numpy-discussion@python.org",
+    description="PEP 561 type stubs for numpy",
+    url="http://www.numpy.org",
+    license='BSD',
+    version="0.0.1",
+    packages=find_packages(),
+
+    # PEP 561 requires these
+    install_requires=['numpy~=1.13.0'],
+    package_data={
+    	'numpy': 'py.typed'
+    },
+)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+Testing
+=======
+
+To run these tests:
+
+    export MYPYPATH='..'
+    mypy test_simple.py
+
+In future, this should change to use the test framework used by mypy.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+def foo(a: np.ndarray): pass
+
+foo(np.array(1))


### PR DESCRIPTION
It doesn't appear that the released mypy supports _stub packages right now, so for now we have to add to MYPYPATH manually.

Something else to consider is how to sync versions with numpy, but we can deal with that later, if we start our numbers low enough.

This adds a very small number of stubs just to verify that installation maybe works.

Fixes #2.